### PR TITLE
chore(deps): update wasm-bindgen ecosystem and base64

### DIFF
--- a/rs_lib/Cargo.toml
+++ b/rs_lib/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "=0.2.106"
-js-sys = "0.3.83"
+wasm-bindgen = "=0.2.125"
+js-sys = "0.3.102"
 ibe = {version = "0.2.3", features = ["cgwkv"]}
 rand = "0.8.4"
 getrandom = { version = "0.2.7", features = ["js"] }
@@ -19,6 +19,6 @@ irmaseal-curve = { version = "0.1.4", features = [
 ] }
 group = "0.13.0"
 serde = "1.0.140"
-base64 = "0.21.0"
+base64 = "0.22.1"
 subtle = "2.4.1"
-serde-wasm-bindgen = "0.4.3"
+serde-wasm-bindgen = "0.6.5"


### PR DESCRIPTION
## 概要
Rust(`rs_lib`)の依存を安全に更新できる範囲で最新化しました。

### 更新したクレート
| crate | before | after |
|---|---|---|
| wasm-bindgen | =0.2.106 | =0.2.125 |
| js-sys | 0.3.83 | 0.3.102 |
| serde-wasm-bindgen | 0.4.3 | 0.6.5 |
| base64 | 0.21.0 | 0.22.1 |

### 検証
- `cargo check` ✅
- `cargo build --target wasm32-unknown-unknown --release` ✅
- `cargo test` の `it_works` はネイティブで `Uint8Array` を使うため**変更前から失敗する既存テスト**（回帰ではありません）

### 意図的に据え置いたクレート
`ibe` / `irmaseal-curve` / `group` / `rand` / `getrandom` のメジャー更新は、IBE のバイトフォーマットや RNG のトレイトバージョンを変えるため、**既存の鍵（`master.key` / `secret.json`）との互換性を壊すリスク**があります。暗号スキームのバージョンアップは単なる依存更新ではなく破壊的変更となるため、本 PR では据え置きました。必要であれば別途、互換性検証込みで対応します。

### 補足（この環境の制約）
- `lib/rs_lib.generated.js` / `lib/rs_lib_bg.wasm` は `deno task wasmbuild` で再生成される成果物です。現状は 0.2.106 ABI で内部整合しており、次回ビルドで 0.2.125 に再生成されます（中間で壊れる状態にはなりません）。
- Deno/JSR 依存（`@hono/hono`, `@std/*`）は、実行環境のネットワークポリシーにより `jsr.io` へ到達できず（403 / GoAway）、メタデータ取得と `deno.lock` の再生成ができないため本 PR では未対応です。ネットワーク許可のある環境で `deno outdated --update` を実行すれば更新できます。

https://claude.ai/code/session_01DwAr3Ln3GjtQpdRj7pw2V6

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwAr3Ln3GjtQpdRj7pw2V6)_