### PR TITLE
chore(deps): update ibe to 0.3.0

### DIFF
--- a/rs_lib/Cargo.toml
+++ b/rs_lib/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "=0.2.106"
-js-sys = "0.3.83"
+wasm-bindgen = "=0.2.125"
+js-sys = "0.3.102"
 ibe = {version = "0.2.3", features = ["cgwkv"]}
 rand = "0.8.4"
 getrandom = { version = "0.2.7", features = ["js"] }
@@ -19,6 +19,6 @@ irmaseal-curve = { version = "0.1.4", features = [
 ] }
 group = "0.13.0"
 serde = "1.0.140"
-base64 = "0.21.0"
+base64 = "0.22.1"
 subtle = "2.4.1"
-serde-wasm-bindgen = "0.4.3"
+serde-wasm-bindgen = "0.6.5"

--- a/rs_lib/Cargo.toml
+++ b/rs_lib/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = "=0.2.125"
 js-sys = "0.3.102"
-ibe = {version = "0.2.3", features = ["cgwkv"]}
+ibe = {version = "0.3.0", features = ["cgwkv"]}
 rand = "0.8.4"
 getrandom = { version = "0.2.7", features = ["js"] }
-irmaseal-curve = { version = "0.1.4", features = [
+pg-curve = { version = "0.2.0", features = [
   "alloc",
   "group",
   "pairings"


### PR DESCRIPTION
Follow-up to the dependency refresh (`d9839ad`), updating the `ibe` crate.

## Changes
- `ibe` `0.2.3` → `0.3.0`
- `irmaseal-curve` `0.1.4` → `pg-curve` `0.2.0`

`ibe` 0.3.0 replaced its `irmaseal-curve` dependency with the renamed successor crate `pg-curve` (same BLS12-381 implementation by the same authors). The `rs_lib` crate declared `irmaseal-curve` only as a manifest dependency — it isn't referenced directly in `src/lib.rs` — so this is a straight rename with matching `alloc`/`group`/`pairings` features.

## Verification
- `cargo build` (native) ✅
- `cargo build --target wasm32-unknown-unknown --release` ✅

## Notes
- `Cargo.lock` is gitignored, so only the manifest is tracked.
- The generated wasm artifacts under `lib/` are produced separately via `deno task wasmbuild`; they were not regenerated here (the wasmbuild tool needs jsr.io, which this environment's network policy blocks). This matches the prior `chore(deps)` commit, which also updated only the manifest.

https://claude.ai/code/session_01DSWHjAMTCHMmEkUcC3tveq

---
_Generated by [Claude Code](https://claude.ai/code/session_01DSWHjAMTCHMmEkUcC3tveq)_